### PR TITLE
Fix critical bug, QOL changes

### DIFF
--- a/OmnifactoryMigrate.py
+++ b/OmnifactoryMigrate.py
@@ -13,16 +13,19 @@ new_path=input("Enter the path to the new version's minecraft folder.\n")
 
 #This will take the important folders/files recommended on the Omnifactory GitHub and copy them to the new instance folder.
 def copyFiles(old_path,new_path):
-    shutil.rmtree(os.path.join(new_path,'saves'))
+    if os.path.exists(os.path.join(new_path,'saves')):
+        shutil.rmtree(os.path.join(new_path,'saves'))
     shutil.copytree(os.path.join(old_path,'saves'), os.path.join(new_path,'saves'))
     
-    shutil.rmtree(os.path.join(new_path,'resourcepacks'))
+    if os.path.exists(os.path.join(new_path,'resourcepacks')):
+        shutil.rmtree(os.path.join(new_path,'resourcepacks'))
     shutil.copytree(os.path.join(old_path,'resourcepacks'), os.path.join(new_path,'resourcepacks'))
     
     os.remove(os.path.join(new_path,'options.txt'))
     shutil.copyfile(os.path.join(old_path,'options.txt'), os.path.join(new_path,'options.txt'))
     
-    shutil.rmtree(os.path.join(new_path,'journeymap'))
+    if os.path.exists(os.path.join(new_path,'journeymap')):
+        shutil.rmtree(os.path.join(new_path,'journeymap'))
     shutil.copytree(os.path.join(old_path,'journeymap'), os.path.join(new_path,'journeymap'))
     
     os.remove(os.path.join(new_path,'config','jei','bookmarks.ini'))

--- a/OmnifactoryMigrate.py
+++ b/OmnifactoryMigrate.py
@@ -7,8 +7,8 @@ import shutil
 
 print("Before you continue, make sure you have imported the new instance in MultiMC from the zip file first!\n")
 
-old_path=input("Enter the path to the old version's minecraft folder.\n")
-new_path=input("Enter the path to the new version's minecraft folder.\n")
+old_path=os.path.expanduser(input("Enter the path to the old version's minecraft folder.\n"))
+new_path=os.path.expanduser(input("Enter the path to the new version's minecraft folder.\n"))
 
 
 #This will take the important folders/files recommended on the Omnifactory GitHub and copy them to the new instance folder.

--- a/OmnifactoryMigrate.py
+++ b/OmnifactoryMigrate.py
@@ -21,14 +21,12 @@ def copyFiles(old_path,new_path):
         shutil.rmtree(os.path.join(new_path,'resourcepacks'))
     shutil.copytree(os.path.join(old_path,'resourcepacks'), os.path.join(new_path,'resourcepacks'))
     
-    os.remove(os.path.join(new_path,'options.txt'))
     shutil.copyfile(os.path.join(old_path,'options.txt'), os.path.join(new_path,'options.txt'))
     
     if os.path.exists(os.path.join(new_path,'journeymap')):
         shutil.rmtree(os.path.join(new_path,'journeymap'))
     shutil.copytree(os.path.join(old_path,'journeymap'), os.path.join(new_path,'journeymap'))
     
-    os.remove(os.path.join(new_path,'config','jei','bookmarks.ini'))
     shutil.copyfile(os.path.join(old_path,'config','jei','bookmarks.ini'), os.path.join(new_path,'config','jei','bookmarks.ini'))
 
 print("Copying Files...\n")


### PR DESCRIPTION
1. Fixes a critical bug where `shutil.rmtree` would be run on a directory that doesn't exist, causing the script to fail and exit
2. Add `os.path.expanduser` calls to the input, allowing users to use ~ to represent their home directory when typing the file path
3. Deletes unecessary `os.remove` calls on options.txt and bookmarks.ini, as `shutil.copyfile` will replace if the file already exists